### PR TITLE
fix(stripe): pass source_transaction so transfers debit pending settlement

### DIFF
--- a/lib/stripe/transfer.ts
+++ b/lib/stripe/transfer.ts
@@ -31,7 +31,7 @@ export async function transferToSwiper(
 
   const { data: payment } = await service
     .from('payments')
-    .select('id, payee_id, amount_cents, platform_fee_cents')
+    .select('id, payee_id, amount_cents, platform_fee_cents, stripe_payment_intent_id')
     .eq('order_id', orderId)
     .eq('status', 'succeeded')
     .maybeSingle()
@@ -51,6 +51,39 @@ export async function transferToSwiper(
     return
   }
 
+  // Resolve the source charge so the transfer can debit pending settlement
+  // funds (otherwise Stripe rejects with `balance_insufficient` while the
+  // orderer's charge is still in the ~2-day settlement window).
+  let chargeId: string | null = null
+  try {
+    const pi = await getStripe().paymentIntents.retrieve(
+      payment.stripe_payment_intent_id
+    )
+    chargeId =
+      typeof pi.latest_charge === 'string'
+        ? pi.latest_charge
+        : pi.latest_charge?.id ?? null
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Unknown error'
+    console.error(`Transfer failed for order ${orderId}: ${message}`)
+    await service
+      .from('payments')
+      .update({ transfer_failed_at: new Date().toISOString() })
+      .eq('order_id', orderId)
+    return
+  }
+
+  if (!chargeId) {
+    console.error(
+      `Transfer failed for order ${orderId}: missing latest_charge on PaymentIntent ${payment.stripe_payment_intent_id}`
+    )
+    await service
+      .from('payments')
+      .update({ transfer_failed_at: new Date().toISOString() })
+      .eq('order_id', orderId)
+    return
+  }
+
   const transferAmount = payment.amount_cents - payment.platform_fee_cents
 
   try {
@@ -59,6 +92,7 @@ export async function transferToSwiper(
         amount: transferAmount,
         currency: 'usd',
         destination: stripeAccount.stripe_account_id,
+        source_transaction: chargeId,
         metadata: { order_id: orderId },
       },
       { idempotencyKey: `transfer-${orderId}` }

--- a/tests/unit/stripe/transfer.test.ts
+++ b/tests/unit/stripe/transfer.test.ts
@@ -10,10 +10,12 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 // transfer.ts imports `server-only`, which throws under vitest's jsdom env.
 vi.mock('server-only', () => ({}))
 
-const { mockServiceFrom, mockTransfersCreate } = vi.hoisted(() => ({
-  mockServiceFrom: vi.fn(),
-  mockTransfersCreate: vi.fn(),
-}))
+const { mockServiceFrom, mockTransfersCreate, mockPaymentIntentsRetrieve } =
+  vi.hoisted(() => ({
+    mockServiceFrom: vi.fn(),
+    mockTransfersCreate: vi.fn(),
+    mockPaymentIntentsRetrieve: vi.fn(),
+  }))
 
 vi.mock('@/lib/supabase/service', () => ({
   createServiceClient: vi.fn(() => ({ from: mockServiceFrom })),
@@ -22,6 +24,7 @@ vi.mock('@/lib/supabase/service', () => ({
 vi.mock('@/lib/stripe/client', () => ({
   getStripe: vi.fn(() => ({
     transfers: { create: mockTransfersCreate },
+    paymentIntents: { retrieve: mockPaymentIntentsRetrieve },
   })),
 }))
 
@@ -29,6 +32,8 @@ import { transferToSwiper } from '@/lib/stripe/transfer'
 
 const ORDER_ID = '00000000-0000-4000-8000-000000000100'
 const SWIPER_ID = '00000000-0000-4000-8000-000000000001'
+const PI_ID = 'pi_test_123'
+const CHARGE_ID = 'ch_test_abc'
 
 function chain(result: { data?: unknown; error?: unknown } = { data: null, error: null }) {
   const mock: Record<string, unknown> = {}
@@ -42,13 +47,24 @@ function chain(result: { data?: unknown; error?: unknown } = { data: null, error
   return mock
 }
 
+function paymentRow(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'pay-1',
+    payee_id: null,
+    amount_cents: 2000,
+    platform_fee_cents: 200,
+    stripe_payment_intent_id: PI_ID,
+    ...overrides,
+  }
+}
+
 beforeEach(() => {
   vi.clearAllMocks()
 })
 
 describe('transferToSwiper', () => {
-  it('creates a Stripe transfer and marks payment.payee_id when payment is unpaid', async () => {
-    const paymentChain = chain({ data: { id: 'pay-1', payee_id: null, amount_cents: 2000, platform_fee_cents: 200 } })
+  it('creates a Stripe transfer with source_transaction and marks payment.payee_id when payment is unpaid', async () => {
+    const paymentChain = chain({ data: paymentRow() })
     const accountChain = chain({ data: { stripe_account_id: 'acct_swiper' } })
     const payeeUpdateChain = chain({ data: null, error: null })
     mockServiceFrom
@@ -56,24 +72,27 @@ describe('transferToSwiper', () => {
       .mockReturnValueOnce(accountChain) // stripe_accounts.select
       .mockReturnValueOnce(payeeUpdateChain) // payments.update payee_id
 
+    mockPaymentIntentsRetrieve.mockResolvedValue({ latest_charge: CHARGE_ID })
     mockTransfersCreate.mockResolvedValue({ id: 'tr_1' })
 
     await transferToSwiper(ORDER_ID, SWIPER_ID)
 
+    expect(mockPaymentIntentsRetrieve).toHaveBeenCalledWith(PI_ID)
     expect(mockTransfersCreate).toHaveBeenCalledWith(
-      expect.objectContaining({
+      {
         amount: 1800,
         currency: 'usd',
         destination: 'acct_swiper',
+        source_transaction: CHARGE_ID,
         metadata: { order_id: ORDER_ID },
-      }),
-      expect.objectContaining({ idempotencyKey: `transfer-${ORDER_ID}` })
+      },
+      { idempotencyKey: `transfer-${ORDER_ID}` }
     )
     expect(payeeUpdateChain.update).toHaveBeenCalledWith({ payee_id: SWIPER_ID })
   })
 
-  it('does NOT write orders.status to "paid" (the OrderStatus enum has no such value)', async () => {
-    const paymentChain = chain({ data: { id: 'pay-1', payee_id: null, amount_cents: 2000, platform_fee_cents: 200 } })
+  it('passes source_transaction when latest_charge is returned as a string', async () => {
+    const paymentChain = chain({ data: paymentRow() })
     const accountChain = chain({ data: { stripe_account_id: 'acct_swiper' } })
     const payeeUpdateChain = chain({ data: null, error: null })
     mockServiceFrom
@@ -81,6 +100,91 @@ describe('transferToSwiper', () => {
       .mockReturnValueOnce(accountChain)
       .mockReturnValueOnce(payeeUpdateChain)
 
+    mockPaymentIntentsRetrieve.mockResolvedValue({ latest_charge: 'ch_str' })
+    mockTransfersCreate.mockResolvedValue({ id: 'tr_1' })
+
+    await transferToSwiper(ORDER_ID, SWIPER_ID)
+
+    expect(mockTransfersCreate).toHaveBeenCalledWith(
+      expect.objectContaining({ source_transaction: 'ch_str' }),
+      expect.anything()
+    )
+  })
+
+  it('passes source_transaction when latest_charge is returned as an expanded charge object', async () => {
+    const paymentChain = chain({ data: paymentRow() })
+    const accountChain = chain({ data: { stripe_account_id: 'acct_swiper' } })
+    const payeeUpdateChain = chain({ data: null, error: null })
+    mockServiceFrom
+      .mockReturnValueOnce(paymentChain)
+      .mockReturnValueOnce(accountChain)
+      .mockReturnValueOnce(payeeUpdateChain)
+
+    mockPaymentIntentsRetrieve.mockResolvedValue({ latest_charge: { id: 'ch_obj' } })
+    mockTransfersCreate.mockResolvedValue({ id: 'tr_1' })
+
+    await transferToSwiper(ORDER_ID, SWIPER_ID)
+
+    expect(mockTransfersCreate).toHaveBeenCalledWith(
+      expect.objectContaining({ source_transaction: 'ch_obj' }),
+      expect.anything()
+    )
+  })
+
+  it('marks transfer_failed_at and skips the transfer when latest_charge is null', async () => {
+    const paymentChain = chain({ data: paymentRow() })
+    const accountChain = chain({ data: { stripe_account_id: 'acct_swiper' } })
+    const failureUpdateChain = chain({ data: null, error: null })
+    mockServiceFrom
+      .mockReturnValueOnce(paymentChain) // payments.select
+      .mockReturnValueOnce(accountChain) // stripe_accounts.select
+      .mockReturnValueOnce(failureUpdateChain) // payments.update transfer_failed_at
+
+    mockPaymentIntentsRetrieve.mockResolvedValue({ latest_charge: null })
+
+    await transferToSwiper(ORDER_ID, SWIPER_ID)
+
+    expect(mockTransfersCreate).not.toHaveBeenCalled()
+    expect(failureUpdateChain.update).toHaveBeenCalledWith(
+      expect.objectContaining({ transfer_failed_at: expect.any(String) })
+    )
+    expect(failureUpdateChain.eq).toHaveBeenCalledWith('order_id', ORDER_ID)
+    // payments.select + stripe_accounts.select + payments.update(transfer_failed_at) === 3
+    // No payee_id update.
+    expect(mockServiceFrom).toHaveBeenCalledTimes(3)
+  })
+
+  it('marks transfer_failed_at and skips the transfer when paymentIntents.retrieve throws', async () => {
+    const paymentChain = chain({ data: paymentRow() })
+    const accountChain = chain({ data: { stripe_account_id: 'acct_swiper' } })
+    const failureUpdateChain = chain({ data: null, error: null })
+    mockServiceFrom
+      .mockReturnValueOnce(paymentChain)
+      .mockReturnValueOnce(accountChain)
+      .mockReturnValueOnce(failureUpdateChain)
+
+    mockPaymentIntentsRetrieve.mockRejectedValue(new Error('pi gone'))
+
+    await transferToSwiper(ORDER_ID, SWIPER_ID)
+
+    expect(mockTransfersCreate).not.toHaveBeenCalled()
+    expect(failureUpdateChain.update).toHaveBeenCalledWith(
+      expect.objectContaining({ transfer_failed_at: expect.any(String) })
+    )
+    expect(failureUpdateChain.eq).toHaveBeenCalledWith('order_id', ORDER_ID)
+    expect(mockServiceFrom).toHaveBeenCalledTimes(3)
+  })
+
+  it('does NOT write orders.status to "paid" (the OrderStatus enum has no such value)', async () => {
+    const paymentChain = chain({ data: paymentRow() })
+    const accountChain = chain({ data: { stripe_account_id: 'acct_swiper' } })
+    const payeeUpdateChain = chain({ data: null, error: null })
+    mockServiceFrom
+      .mockReturnValueOnce(paymentChain)
+      .mockReturnValueOnce(accountChain)
+      .mockReturnValueOnce(payeeUpdateChain)
+
+    mockPaymentIntentsRetrieve.mockResolvedValue({ latest_charge: CHARGE_ID })
     mockTransfersCreate.mockResolvedValue({ id: 'tr_1' })
 
     await transferToSwiper(ORDER_ID, SWIPER_ID)
@@ -92,7 +196,7 @@ describe('transferToSwiper', () => {
   })
 
   it('marks payments.transfer_failed_at when stripe.transfers.create rejects', async () => {
-    const paymentChain = chain({ data: { id: 'pay-1', payee_id: null, amount_cents: 2000, platform_fee_cents: 200 } })
+    const paymentChain = chain({ data: paymentRow() })
     const accountChain = chain({ data: { stripe_account_id: 'acct_swiper' } })
     const failureUpdateChain = chain({ data: null, error: null })
     mockServiceFrom
@@ -100,6 +204,7 @@ describe('transferToSwiper', () => {
       .mockReturnValueOnce(accountChain) // stripe_accounts.select
       .mockReturnValueOnce(failureUpdateChain) // payments.update transfer_failed_at
 
+    mockPaymentIntentsRetrieve.mockResolvedValue({ latest_charge: CHARGE_ID })
     mockTransfersCreate.mockRejectedValue(new Error('stripe down'))
 
     await expect(transferToSwiper(ORDER_ID, SWIPER_ID)).resolves.toBeUndefined()
@@ -117,17 +222,19 @@ describe('transferToSwiper', () => {
 
     await transferToSwiper(ORDER_ID, SWIPER_ID)
 
+    expect(mockPaymentIntentsRetrieve).not.toHaveBeenCalled()
     expect(mockTransfersCreate).not.toHaveBeenCalled()
     // Only the initial payments.select happens; no follow-up update
     expect(mockServiceFrom).toHaveBeenCalledTimes(1)
   })
 
   it('does nothing when payment is already paid (payee_id set)', async () => {
-    const paidChain = chain({ data: { id: 'pay-1', payee_id: SWIPER_ID, amount_cents: 2000, platform_fee_cents: 200 } })
+    const paidChain = chain({ data: paymentRow({ payee_id: SWIPER_ID }) })
     mockServiceFrom.mockReturnValueOnce(paidChain)
 
     await transferToSwiper(ORDER_ID, SWIPER_ID)
 
+    expect(mockPaymentIntentsRetrieve).not.toHaveBeenCalled()
     expect(mockTransfersCreate).not.toHaveBeenCalled()
     expect(mockServiceFrom).toHaveBeenCalledTimes(1)
   })


### PR DESCRIPTION
## Summary

- Resolve `latest_charge` from the PaymentIntent and pass it as `source_transaction` on `stripe.transfers.create`, so the transfer can debit pending settlement funds instead of failing with `balance_insufficient` while the orderer's charge is still in the ~2-day settlement window.
- Mark `payments.transfer_failed_at` on PI-retrieve failure or missing `latest_charge` so ops can find stuck transfers (mirrors existing handling for `transfers.create` failures).
- Tests cover all four branches: `latest_charge` as string, expanded charge object, null, and `paymentIntents.retrieve` throwing.

## Test plan

- [x] `npx vitest run tests/unit/stripe/transfer.test.ts` — 9/9 passing
- [x] Manual: complete an order, confirm Stripe transfer succeeds within the settlement window (previously hit `balance_insufficient`)
- [x] Manual: force a PI-retrieve failure, verify `payments.transfer_failed_at` is set and the transfer is skipped